### PR TITLE
fix(main): resolve shell PATH not inherited in macOS GUI-launched app

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,21 +6,31 @@ import * as http from "http";
 import * as https from "https";
 import * as path from "path";
 
-// Fix PATH for macOS/Linux: GUI-launched Electron apps don't inherit the user's shell PATH.
+// Fix PATH for macOS: GUI-launched Electron apps (Finder/Dock) don't inherit the user's shell PATH.
 // This reads the actual PATH from a login shell so tools like npm/pnpm can be found.
 // Uses unique delimiters to extract PATH cleanly, ignoring any shell startup noise (banners, motd, etc.).
-if (process.platform !== "win32") {
+if (process.platform === "darwin") {
+    const defaultPath = process.env.PATH;
     try {
         const userShell = process.env.SHELL || "/bin/zsh";
-        const output = execFileSync(userShell, ["-ilc", "echo __PPTB_PATH_START__$PATH__PPTB_PATH_END__"], {
+        const output = execFileSync(userShell, ["-ilc", 'printf "__PPTB_PATH_START__"; printenv PATH; printf "__PPTB_PATH_END__"'], {
             encoding: "utf8",
+            timeout: 3000,
+            maxBuffer: 1024 * 1024,
         });
-        const match = output.match(/__PPTB_PATH_START__(.+)__PPTB_PATH_END__/);
-        if (match?.[1]) {
-            process.env.PATH = match[1];
+        const startDelimiter = "__PPTB_PATH_START__";
+        const endDelimiter = "__PPTB_PATH_END__";
+        const startIndex = output.indexOf(startDelimiter);
+        const endIndex = output.indexOf(endDelimiter, startIndex + startDelimiter.length);
+        if (startIndex !== -1 && endIndex !== -1) {
+            const extractedPath = output.slice(startIndex + startDelimiter.length, endIndex).trim();
+            if (extractedPath) {
+                process.env.PATH = extractedPath;
+            }
         }
     } catch {
-        // Silently ignore — keeps the default system PATH
+        // Restore default PATH on failure (timeout, shell error, etc.)
+        process.env.PATH = defaultPath;
     }
 }
 import {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,9 +1,28 @@
+import { execFileSync } from "child_process";
 import { app, BrowserWindow, dialog, ipcMain, Menu, MenuItemConstructorOptions, nativeTheme, shell } from "electron";
 import * as fs from "fs";
 import { createWriteStream } from "fs";
 import * as http from "http";
 import * as https from "https";
 import * as path from "path";
+
+// Fix PATH for macOS/Linux: GUI-launched Electron apps don't inherit the user's shell PATH.
+// This reads the actual PATH from a login shell so tools like npm/pnpm can be found.
+// Uses unique delimiters to extract PATH cleanly, ignoring any shell startup noise (banners, motd, etc.).
+if (process.platform !== "win32") {
+    try {
+        const userShell = process.env.SHELL || "/bin/zsh";
+        const output = execFileSync(userShell, ["-ilc", "echo __PPTB_PATH_START__$PATH__PPTB_PATH_END__"], {
+            encoding: "utf8",
+        });
+        const match = output.match(/__PPTB_PATH_START__(.+)__PPTB_PATH_END__/);
+        if (match?.[1]) {
+            process.env.PATH = match[1];
+        }
+    } catch {
+        // Silently ignore — keeps the default system PATH
+    }
+}
 import {
     CONNECTION_CHANNELS,
     DATAVERSE_CHANNELS,


### PR DESCRIPTION
## Summary

- Fixes shell PATH not being inherited when the app is launched from Finder/Dock on macOS
- Reads the user's actual PATH from their login shell at app startup using `execFileSync`
- Uses unique delimiters (`__PPTB_PATH_START__`/`__PPTB_PATH_END__`) to safely extract PATH, ignoring any shell startup noise (banners, motd, debug echo in `.zshrc`/`.bashrc`)

**Why not `fix-path`?** The `fix-path` package (v4+) is ESM-only, which conflicts with the project's CommonJS main process. A dynamic `import()` would introduce a race condition before managers are instantiated. This inlines the same technique `fix-path` uses under the hood — without the dependency.

Closes #506

## Test plan

- [ ] Run `pnpm run build` — verify no type/build errors
- [ ] Run `pnpm run package:mac` — package the app (unsigned with `CSC_IDENTITY_AUTO_DISCOVERY=false`)
- [ ] Open the `.app` from Finder (double-click, **not** from terminal)
- [ ] Enable debug mode, install a tool via npm — should succeed
- [ ] Verify terminal spawning and browser detection also work