### PR TITLE
#591, #561 fix: update Dataverse hostname pattern to include new regions and improve URL validation

### DIFF
--- a/src/renderer/modules/connectionManagement.ts
+++ b/src/renderer/modules/connectionManagement.ts
@@ -1455,16 +1455,20 @@ export async function importConnections(): Promise<void> {
 
 /**
  * Hostname pattern for valid Dataverse environments.
- * Matches: *.crm*.dynamics.com (commercial/GCC), *.crm.microsoftdynamics.us (GCC High), *.crm.appsplatform.us (DoD).
+ * Matches: *.crm*.dynamics.com / *.crm*.dynamics.cn / *.api.crm*.dynamics.com (commercial/GCC),
+ * *.crm.microsoftdynamics.us / *.api.crm.microsoftdynamics.us (GCC High),
+ * *.crm.appsplatform.us / *.api.crm.appsplatform.us (DoD).
  * The org-name segment follows RFC 1123 (starts and ends with alphanumeric, hyphens allowed in the middle).
  * \d* is intentionally lenient to accommodate current and future Microsoft region codes (crm, crm4, crm9, crm11, etc.).
  * End-anchored and case-insensitive; applied against the parsed hostname only.
  */
-const DATAVERSE_HOST_PATTERN = /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\.crm\d*\.(dynamics\.com|microsoftdynamics\.us|appsplatform\.us)(\.mcas\.ms)?$/i;
+const DATAVERSE_HOST_PATTERN = /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\.(api\.)?crm\d*\.(dynamics\.com|dynamics\.cn|microsoftdynamics\.us|appsplatform\.us)(\.mcas\.ms)?$/i;
 
 /**
  * Validates that a URL string points to a Dataverse environment hostname.
- * Accepted domains: *.crm*.dynamics.com (commercial/GCC), *.crm.microsoftdynamics.us (GCC High), *.crm.appsplatform.us (DoD).
+ * Accepted domains: *.crm*.dynamics.com / *.crm*.dynamics.cn / *.api.crm*.dynamics.com (commercial/GCC),
+ * *.crm.microsoftdynamics.us / *.api.crm.microsoftdynamics.us (GCC High),
+ * *.crm.appsplatform.us / *.api.crm.appsplatform.us (DoD).
  * Validation is performed against the parsed hostname only (not the path/query) and is case-insensitive.
  */
 function isValidDataverseUrl(rawUrl: string): boolean {
@@ -1564,7 +1568,7 @@ function buildConnectionFromPayload(formPayload: ConnectionFormPayload, mode: "a
 
         // Build connection from parsed data
         const connection: Connection = {
-            id: mode === "add" ? Date.now().toString() : mode === "edit" ? (formPayload.id ?? "") : "test",
+            id: mode === "add" ? Date.now().toString() : mode === "edit" ? formPayload.id ?? "" : "test",
             name: mode === "add" || mode === "edit" ? sanitizeInput(formPayload.name) : "Test Connection",
             url: parsed.url,
             environment: mode === "add" || mode === "edit" ? normalizeEnvironment(formPayload.environment) : "Test",
@@ -1602,7 +1606,7 @@ function buildConnectionFromPayload(formPayload: ConnectionFormPayload, mode: "a
 
     // Standard connection building for non-connection-string types
     const connection: Connection = {
-        id: mode === "add" ? Date.now().toString() : mode === "edit" ? (formPayload.id ?? "") : "test",
+        id: mode === "add" ? Date.now().toString() : mode === "edit" ? formPayload.id ?? "" : "test",
         name: mode === "add" || mode === "edit" ? sanitizeInput(formPayload.name) : "Test Connection",
         url: sanitizeInput(formPayload.url),
         environment: mode === "add" || mode === "edit" ? normalizeEnvironment(formPayload.environment) : "Test",
@@ -2084,7 +2088,9 @@ export async function loadSidebarConnections(): Promise<void> {
                     const safeCatColor = catColor && /^#[0-9A-Fa-f]{6}$/.test(catColor) ? escapeHtml(catColor) : "";
                     const colorSwatchHtml =
                         groupKey !== ""
-                            ? `<input type="color" class="connection-group-color-picker" value="${safeCatColor || "#888888"}" data-category-key="${escapeHtml(groupKey)}" title="Change category color" />`
+                            ? `<input type="color" class="connection-group-color-picker" value="${safeCatColor || "#888888"}" data-category-key="${escapeHtml(
+                                  groupKey,
+                              )}" title="Change category color" />`
                             : "";
                     const items = groupConns.map(renderConnectionItem).join("");
                     return `
@@ -2094,7 +2100,9 @@ export async function loadSidebarConnections(): Promise<void> {
                             ${colorSwatchHtml}
                             <span class="connection-group-count">${groupConns.length}</span>
                             <span class="connection-group-toggle">▼</span>
-                            <button class="connection-group-export-btn" data-category-key="${escapeHtml(groupKey)}" title="Export ${escapedKey} connections" aria-label="Export ${escapedKey} connections">
+                            <button class="connection-group-export-btn" data-category-key="${escapeHtml(
+                                groupKey,
+                            )}" title="Export ${escapedKey} connections" aria-label="Export ${escapedKey} connections">
                                 <img src="${exportIconPath}" width="12" height="12" alt="Export ${escapedKey} connections" class="connection-group-export-icon" />
                             </button>
                         </div>


### PR DESCRIPTION
## Summary

added validation for urls like api.crm(*).dynamics.com and crm(*).dynamics.cn

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Chore / maintenance (dependency update, build, config)
- [ ] Test addition / improvement

## Changes

just changed REGEX for URL validation

## Architecture checklist

### Packages (`types` & `validation`)

- [x] **Not applicable** — no changes to `packages/`

If you did change a package:

- [ ] `@pptb/types` (`types`): type definitions updated and version bumped in `packages/types/package.json`
- [ ] `@pptb/validate` (`validation`): validation rules updated and version bumped in `packages/validation/package.json`

### Code quality

- [x] `pnpm run typecheck` passes with **0 errors** (warnings are acceptable)
- [x] `pnpm run lint` passes with **0 errors** (warnings are acceptable)
- [x] `pnpm run build` completes successfully

## Testing

- [x] `pnpm run test:unit` passes (for changes to `src/main/`, `src/common/`, or `src/renderer/` utilities)
- [x] `pnpm run test:e2e` passes (for UI / navigation / end-to-end flows)
- [x] Manually tested in the running app (`pnpm run dev`)

**Scenario tested:**

-

## Screenshots / recordings

-

## Breaking changes

- [x] No breaking changes
- [ ] Yes — describe impact and migration path below:

## Reviewer notes

- [ ] I have added appropriate unit and/or e2e tests for this change
- [x] I have resolved all GitHub Copilot review comments
- [x] I have followed the guidelines in [CONTRIBUTING.md](https://github.com/PowerPlatformToolBox/desktop-app/blob/dev/CONTRIBUTING.md#pull-requests)