### PR TITLE
[Feature] add "Update all tools" button and functionality in the sidebar

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -58,6 +58,11 @@
                 <div class="sidebar-content active" id="sidebar-tools">
                     <div class="sidebar-header">
                         <h2 class="sidebar-title">INSTALLED</h2>
+                        <div class="sidebar-header-actions">
+                            <button id="sidebar-update-all-tools-btn" class="sidebar-icon-btn" title="Update all tools" aria-label="Update all tools" style="display: none">
+                                <img id="update-all-tools-icon" width="16" height="16" alt="" aria-hidden="true" />
+                            </button>
+                        </div>
                     </div>
                     <div class="sidebar-search-bar">
                         <div class="sidebar-search-input-wrapper">

--- a/src/renderer/modules/initialization.ts
+++ b/src/renderer/modules/initialization.ts
@@ -4,8 +4,8 @@
  */
 
 import { TOOL_WINDOW_CHANNELS } from "../../common/ipc/channels";
-import { normalizeTelemetryConsent, shouldPromptForTelemetryConsent } from "../../common/telemetryConsent";
 import { logCheckpoint, logError, logInfo, logWarn } from "../../common/logger";
+import { normalizeTelemetryConsent, shouldPromptForTelemetryConsent } from "../../common/telemetryConsent";
 import {
     DEFAULT_CATEGORY_COLOR_THICKNESS,
     DEFAULT_ENVIRONMENT_COLOR_THICKNESS,
@@ -53,7 +53,7 @@ import {
     setupKeyboardShortcuts,
     showHomePage,
 } from "./toolManagement";
-import { clearInstalledToolsDropdownFilters, loadSidebarTools } from "./toolsSidebarManagement";
+import { clearInstalledToolsDropdownFilters, loadSidebarTools, updateAllToolsFromSidebar } from "./toolsSidebarManagement";
 
 /**
  * Initialize the application
@@ -322,6 +322,16 @@ function setupToolbarButtons(): void {
  * Set up sidebar buttons
  */
 function setupSidebarButtons(): void {
+    // Sidebar update all tools button
+    const sidebarUpdateAllToolsBtn = document.getElementById("sidebar-update-all-tools-btn");
+    if (sidebarUpdateAllToolsBtn) {
+        sidebarUpdateAllToolsBtn.addEventListener("click", () => {
+            updateAllToolsFromSidebar().catch((error) => {
+                logError(error instanceof Error ? error : new Error(String(error)));
+            });
+        });
+    }
+
     // Sidebar add connection button
     const sidebarAddConnectionBtn = document.getElementById("sidebar-add-connection-btn");
     if (sidebarAddConnectionBtn) {

--- a/src/renderer/modules/themeManagement.ts
+++ b/src/renderer/modules/themeManagement.ts
@@ -139,6 +139,12 @@ export function updateToolSidebarIconsForTheme(): void {
     const moreIconPath = isDarkTheme ? "icons/dark/more-icon.svg" : "icons/light/more-icon.svg";
     const defaultToolIcon = isDarkTheme ? "icons/dark/tool-default.svg" : "icons/light/tool-default.svg";
 
+    // Update "Update all tools" header button icon (lives outside the tools list container)
+    const updateAllToolsIcon = document.getElementById("update-all-tools-icon") as HTMLImageElement | null;
+    if (updateAllToolsIcon) {
+        updateAllToolsIcon.src = (isDarkTheme ? "icons/dark/update.svg" : "icons/light/update.svg") + cacheBuster;
+    }
+
     const toolsList = document.getElementById("sidebar-tools-list");
     if (!toolsList) return;
 

--- a/src/renderer/modules/toolsSidebarManagement.ts
+++ b/src/renderer/modules/toolsSidebarManagement.ts
@@ -45,6 +45,7 @@ export async function loadSidebarTools(): Promise<void> {
 
             // Add event listener for the marketplace button
             attachMarketplaceNavigationButton("go-to-marketplace-btn", "");
+            updateUpdateAllToolsButton([]);
             return;
         }
 
@@ -65,6 +66,9 @@ export async function loadSidebarTools(): Promise<void> {
                 };
             }),
         );
+
+        // Show/enable the "Update all" header button whenever any installed tool has an update
+        updateUpdateAllToolsButton(toolsWithUpdateInfo);
 
         // Get filter and sort values
         const searchInput = document.getElementById("tools-search-input") as HTMLInputElement | null;
@@ -823,6 +827,90 @@ async function updateToolFromSidebar(toolId: string): Promise<void> {
             type: "error",
         });
         // Reload sidebar to remove updating state
+        await loadSidebarTools();
+    }
+}
+
+/**
+ * Show/hide and enable/disable the "Update all" sidebar header button based on
+ * whether any installed tool currently has an update available or is updating.
+ */
+function updateUpdateAllToolsButton(tools: Array<{ hasUpdate?: boolean; isUpdating?: boolean }>): void {
+    const updateAllBtn = document.getElementById("sidebar-update-all-tools-btn") as HTMLButtonElement | null;
+    if (!updateAllBtn) return;
+
+    const hasAnyUpdate = tools.some((t) => t.hasUpdate);
+    const isAnyUpdating = tools.some((t) => t.isUpdating);
+
+    updateAllBtn.style.display = hasAnyUpdate ? "flex" : "none";
+    updateAllBtn.disabled = isAnyUpdating;
+    updateAllBtn.title = isAnyUpdating ? "Updating tools..." : "Update all tools";
+}
+
+/**
+ * Update every installed tool that has an update available, one at a time
+ * (sequential to avoid concurrent writes to the tool manifest file).
+ */
+export async function updateAllToolsFromSidebar(): Promise<void> {
+    const updateAllBtn = document.getElementById("sidebar-update-all-tools-btn") as HTMLButtonElement | null;
+
+    try {
+        const tools = await window.toolboxAPI.getAllTools();
+        const updateChecks = await Promise.all(
+            tools.map(async (tool) => ({
+                tool,
+                updateInfo: await window.toolboxAPI.checkToolUpdates(tool.id),
+            })),
+        );
+        const toolsToUpdate = updateChecks.filter((entry) => entry.updateInfo.hasUpdate);
+
+        if (toolsToUpdate.length === 0) {
+            return;
+        }
+
+        if (updateAllBtn) {
+            updateAllBtn.disabled = true;
+            updateAllBtn.title = `Updating ${toolsToUpdate.length} tool(s)...`;
+        }
+
+        let succeeded = 0;
+        const failures: string[] = [];
+
+        for (const { tool } of toolsToUpdate) {
+            try {
+                await window.toolboxAPI.updateTool(tool.id);
+                succeeded++;
+            } catch (error) {
+                failures.push(tool.name || tool.id);
+                logError(`Failed to update tool ${tool.id}`, error);
+            }
+            // Refresh the sidebar after each tool so progress/spinners stay accurate
+            await loadSidebarTools();
+        }
+
+        if (failures.length === 0) {
+            await window.toolboxAPI.utils.showNotification({
+                title: "Tools Updated",
+                body: `${succeeded} tool${succeeded === 1 ? "" : "s"} updated successfully.`,
+                type: "success",
+            });
+        } else {
+            await window.toolboxAPI.utils.showNotification({
+                title: "Update Completed with Errors",
+                body: `${succeeded} of ${toolsToUpdate.length} tool(s) updated. Failed: ${failures.join(", ")}.`,
+                type: succeeded > 0 ? "warning" : "error",
+            });
+        }
+
+        await loadMarketplace();
+    } catch (error) {
+        logError("Failed to update all tools", error);
+        await window.toolboxAPI.utils.showNotification({
+            title: "Update Failed",
+            body: `Failed to update tools: ${(error as Error).message}`,
+            type: "error",
+        });
+    } finally {
         await loadSidebarTools();
     }
 }

--- a/src/renderer/styles.scss
+++ b/src/renderer/styles.scss
@@ -3933,6 +3933,11 @@ body.dark-theme .sidebar-icon-btn:hover {
     outline-offset: 2px;
 }
 
+.sidebar-icon-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
 .connection-item-top-tags {
     display: flex;
     gap: 6px;


### PR DESCRIPTION
<!-- PR title format: [Type] Brief description — e.g. [Feature] Add connection export  -->
<!-- Types: [Feature] | [Fix] | [Docs] | [Refactor] | [Chore] | [Test] -->
<!-- Target branch: dev (not main) -->

## Summary

This pull request introduces a new "Update all tools" button to the sidebar, allowing users to update all installed tools with available updates in one click. The implementation includes UI additions, theme-aware icon handling, button state management, and sequential update logic with user notifications.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Chore / maintenance (dependency update, build, config)
- [ ] Test addition / improvement

## Changes

<!-- List the key files/areas changed and what was done. Be specific enough for a reviewer to navigate the diff. -->

**New "Update All Tools" Sidebar Feature:**

* Added a "Update all tools" button to the sidebar header in `index.html` and styled it for proper enable/disable feedback (`.sidebar-icon-btn:disabled`). [[1]](diffhunk://#diff-de1a05372575c0caebae4f1eec3f31d8bbf0c38fcbbfab8773d037d777bb0bf8R61-R65) [[2]](diffhunk://#diff-3d997f8551c77a7a7cf76f39cfff6f479831958c16720a75c4cc47fda38a0411R3936-R3940)
* The button's icon updates automatically to match the current theme (dark/light) in `themeManagement.ts`.

**Sidebar Tools Update Logic:**

* The button is shown only when at least one installed tool has an update available, and is disabled while updates are in progress. Its state is managed in `toolsSidebarManagement.ts`. [[1]](diffhunk://#diff-efabd05a4c9c616786d7f7e8a84083338f0aaf181c9a76170784c664af36405cR70-R72) [[2]](diffhunk://#diff-efabd05a4c9c616786d7f7e8a84083338f0aaf181c9a76170784c664af36405cR834-R917)
* Clicking the button sequentially updates all tools with available updates, shows progress, and provides success/error notifications to the user. [[1]](diffhunk://#diff-c8876483c2f5fb3f6c5d0b2efe799f602a505ec4e4e49aebf9e43b635ca4aca5L56-R56) [[2]](diffhunk://#diff-c8876483c2f5fb3f6c5d0b2efe799f602a505ec4e4e49aebf9e43b635ca4aca5R325-R334) [[3]](diffhunk://#diff-efabd05a4c9c616786d7f7e8a84083338f0aaf181c9a76170784c664af36405cR834-R917)

**Code Structure and Integration:**

* Updated imports and initialization logic to wire up the new button and its handler in `initialization.ts`. [[1]](diffhunk://#diff-c8876483c2f5fb3f6c5d0b2efe799f602a505ec4e4e49aebf9e43b635ca4aca5L7-R8) [[2]](diffhunk://#diff-c8876483c2f5fb3f6c5d0b2efe799f602a505ec4e4e49aebf9e43b635ca4aca5L56-R56) [[3]](diffhunk://#diff-c8876483c2f5fb3f6c5d0b2efe799f602a505ec4e4e49aebf9e43b635ca4aca5R325-R334)
* Ensured the button and sidebar state are refreshed appropriately after updates, including after individual tool updates and theme changes. [[1]](diffhunk://#diff-efabd05a4c9c616786d7f7e8a84083338f0aaf181c9a76170784c664af36405cR48) [[2]](diffhunk://#diff-efabd05a4c9c616786d7f7e8a84083338f0aaf181c9a76170784c664af36405cR834-R917)

These changes collectively provide a streamlined and user-friendly way to keep all installed tools up to date directly from the sidebar.

## Architecture checklist

### Packages (`types` & `validation`)

<!-- Only fill in this section if you touched files under packages/. Otherwise delete it. -->

- [x] **Not applicable** — no changes to `packages/`

If you did change a package:

- [ ] `@pptb/types` (`types`): type definitions updated and version bumped in `packages/types/package.json`
- [ ] `@pptb/validate` (`validation`): validation rules updated and version bumped in `packages/validation/package.json`

### Code quality

- [x] `pnpm run typecheck` passes with **0 errors** (warnings are acceptable)
- [x] `pnpm run lint` passes with **0 errors** (warnings are acceptable)
- [x] `pnpm run build` completes successfully

## Testing

<!-- Describe how you verified this change works. -->

- [x] `pnpm run test:unit` passes (for changes to `src/main/`, `src/common/`, or `src/renderer/` utilities)
- [x] `pnpm run test:e2e` passes (for UI / navigation / end-to-end flows)
- [x] Manually tested in the running app (`pnpm run dev`)

**Scenario tested:**

<!-- e.g. "Opened the app, navigated to X, confirmed Y behaviour" -->

## Screenshots / recordings

<!-- Attach screenshots or a short screen recording for any UI change. Delete this section if not applicable. -->

## Breaking changes

<!-- Does this change affect the tool API (`toolboxAPI` / `dataverseAPI`), existing IPC channels, or `pptoolbox-types`? -->

- [x] No breaking changes
- [ ] Yes — describe impact and migration path below:

<!-- Breaking change details -->

## Reviewer notes

<!-- Anything specific you'd like reviewers to focus on, or context that helps them review faster. -->

- [x] I have added appropriate unit and/or e2e tests for this change
- [x] I have resolved all GitHub Copilot review comments
- [x] I have followed the guidelines in [CONTRIBUTING.md](https://github.com/PowerPlatformToolBox/desktop-app/blob/dev/CONTRIBUTING.md#pull-requests)
