### PR TITLE
[Feature] Enhance tool features with connectionless

### DIFF
--- a/packages/lib/validate.js
+++ b/packages/lib/validate.js
@@ -9,7 +9,7 @@
 /** @typedef {{ name: string; url?: string }} Contributor */
 /** @typedef {{ "connect-src"?: string[]; "script-src"?: string[]; "style-src"?: string[]; "img-src"?: string[]; "font-src"?: string[]; "frame-src"?: string[]; "media-src"?: string[] }} CspExceptions */
 /** @typedef {{ repository?: string; website?: string; funding?: string; readmeUrl?: string }} Configurations */
-/** @typedef {{ multiConnection?: "required" | "optional" | "none"; minAPI?: string; enabledForPowerPlatformAPI?: boolean }} Features */
+/** @typedef {{ multiConnection?: "required" | "optional" | "none"; connectionRequirement?: "required" | "optional"; minAPI?: string; enabledForPowerPlatformAPI?: boolean }} Features */
 /**
  * @typedef {{
  *   name: string;
@@ -60,6 +60,9 @@ const APPROVED_LICENSES = ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", 
 
 // Valid multiConnection values
 const VALID_MULTI_CONNECTION_VALUES = ["required", "optional", "none"];
+
+// Valid connectionRequirement values
+const VALID_CONNECTION_REQUIREMENT_VALUES = ["required", "optional"];
 
 // Semver regex for minAPI validation
 const SEMVER_REGEX = /^\d+\.\d+\.\d+(-[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$/;
@@ -312,9 +315,9 @@ async function validatePackageJson(packageJson, options = {}) {
         const features = packageJson.features;
 
         if (features === null || typeof features !== "object" || Array.isArray(features)) {
-            errors.push("features must be a non-array object with optional 'multiConnection', 'minAPI', and 'enabledForPowerPlatformAPI' properties");
+            errors.push("features must be a non-array object with optional 'multiConnection', 'connectionRequirement', 'minAPI', and 'enabledForPowerPlatformAPI' properties");
         } else {
-            const VALID_FEATURE_KEYS = ["multiConnection", "minAPI", "enabledForPowerPlatformAPI"];
+            const VALID_FEATURE_KEYS = ["multiConnection", "connectionRequirement", "minAPI", "enabledForPowerPlatformAPI"];
             const featureKeys = Object.keys(features);
             const invalidKeys = featureKeys.filter((key) => !VALID_FEATURE_KEYS.includes(key));
 
@@ -326,6 +329,10 @@ async function validatePackageJson(packageJson, options = {}) {
                 errors.push("features.multiConnection is required when features object is provided");
             } else if (!VALID_MULTI_CONNECTION_VALUES.includes(features.multiConnection)) {
                 errors.push(`features.multiConnection must be one of: ${VALID_MULTI_CONNECTION_VALUES.join(", ")}`);
+            }
+
+            if (features.connectionRequirement !== undefined && !VALID_CONNECTION_REQUIREMENT_VALUES.includes(features.connectionRequirement)) {
+                errors.push(`features.connectionRequirement must be one of: ${VALID_CONNECTION_REQUIREMENT_VALUES.join(", ")}`);
             }
 
             if (features.minAPI !== undefined) {
@@ -467,7 +474,7 @@ function validatePPTBConfig(config) {
                 } else {
                     agents.modes.forEach((mode, idx) => {
                         if (mode !== "one-way" && mode !== "two-way") {
-                            errors.push(`agents.modes[${idx}] must be either \"one-way\" or \"two-way\"`);
+                            errors.push(`agents.modes[${idx}] must be either "one-way" or "two-way"`);
                         }
                     });
                 }

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -106,22 +106,23 @@ npx pptb-validate path/to/package.json
 
 The validator checks every field that the official review pipeline inspects:
 
-| Field                       | Required | Rules                                                                                                                                  |
-| --------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                      | ✅       | Must be a string                                                                                                                       |
-| `version`                   | ✅       | Must be a string                                                                                                                       |
-| `displayName`               | ✅       | Must be a string                                                                                                                       |
-| `description`               | ✅       | Must be a string                                                                                                                       |
-| `license`                   | ✅       | Must be one of the approved OSS licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, GPL-2.0, GPL-3.0, LGPL-3.0, ISC, AGPL-3.0-only) |
-| `contributors`              | ✅       | Non-empty array; each entry needs a `name`                                                                                             |
-| `configurations.repository` | ✅       | Valid, reachable URL                                                                                                                   |
-| `configurations.readmeUrl`  | ✅       | Valid URL; must **not** be hosted on `github.com` (use `raw.githubusercontent.com`)                                                    |
-| `configurations.website`    | ❌       | Valid, reachable URL when provided                                                                                                     |
-| `configurations.funding`    | ❌       | Valid, reachable URL when provided                                                                                                     |
-| `icon`                      | ❌       | Relative path to a `.svg` file bundled under `dist/`; must not be an HTTP URL or an absolute path                                      |
-| `cspExceptions`             | ❌       | When present: must not be empty; only recognised directives; each directive must be a non-empty array                                  |
-| `features.multiConnection`  | ❌\*     | Required when `features` is present; must be `"required"`, `"optional"`, or `"none"`                                                   |
-| `features.minAPI`           | ❌       | Valid semver string when provided                                                                                                      |
+| Field                            | Required | Rules                                                                                                                                     |
+| -------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                           | ✅       | Must be a string                                                                                                                          |
+| `version`                        | ✅       | Must be a string                                                                                                                          |
+| `displayName`                    | ✅       | Must be a string                                                                                                                          |
+| `description`                    | ✅       | Must be a string                                                                                                                          |
+| `license`                        | ✅       | Must be one of the approved OSS licenses (MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, GPL-2.0, GPL-3.0, LGPL-3.0, ISC, AGPL-3.0-only)    |
+| `contributors`                   | ✅       | Non-empty array; each entry needs a `name`                                                                                                |
+| `configurations.repository`      | ✅       | Valid, reachable URL                                                                                                                      |
+| `configurations.readmeUrl`       | ✅       | Valid URL; must **not** be hosted on `github.com` (use `raw.githubusercontent.com`)                                                       |
+| `configurations.website`         | ❌       | Valid, reachable URL when provided                                                                                                        |
+| `configurations.funding`         | ❌       | Valid, reachable URL when provided                                                                                                        |
+| `icon`                           | ❌       | Relative path to a `.svg` file bundled under `dist/`; must not be an HTTP URL or an absolute path                                         |
+| `cspExceptions`                  | ❌       | When present: must not be empty; only recognised directives; each directive must be a non-empty array                                     |
+| `features.multiConnection`       | ❌\*     | Required when `features` is present; must be `"required"`, `"optional"`, or `"none"`                                                      |
+| `features.connectionRequirement` | ❌       | Must be `"required"` or `"optional"` when provided; defaults to `"required"`. `"optional"` lets the tool open with no connection selected |
+| `features.minAPI`                | ❌       | Valid semver string when provided                                                                                                         |
 
 > \* Required only when the `features` object is present.
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -24,7 +24,7 @@
     "pptb-validate": "./bin/pptb-validate.js"
   },
   "dependencies": {
-    "@pptb/validate": "1.0.2-beta.0"
+    "@pptb/validate": "1.0.2"
   },
   "files": [
     "index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pptb/types",
-  "version": "1.2.5",
+  "version": "1.2.6-beta.1",
   "description": "Type definitions for Power Platform ToolBox APIs and validity checks for tool packages",
   "main": "index.d.ts",
   "types": "index.d.ts",
@@ -24,7 +24,7 @@
     "pptb-validate": "./bin/pptb-validate.js"
   },
   "dependencies": {
-    "@pptb/validate": "^0.0.2"
+    "@pptb/validate": "1.0.2-beta.0"
   },
   "files": [
     "index.d.ts",

--- a/packages/types/toolboxAPI.d.ts
+++ b/packages/types/toolboxAPI.d.ts
@@ -504,7 +504,9 @@ declare namespace ToolBoxAPI {
          * `features.multiConnection: "required"` or `"optional"` and
          * `options.secondaryConnectionId` is not provided, PPTB automatically shows
          * the multi-connection selector before launching the callee. The Promise rejects
-         * if the user cancels the selector.
+         * if the user cancels the selector. This prompt is skipped entirely when the callee
+         * declares `features.connectionRequirement: "optional"`, since a connection is never
+         * mandatory for that tool.
          *
          * **`noReturn`**: pass `true` when the caller does not expect the callee to
          * return data (e.g. a "Send To" pattern where data is only sent one-way).

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pptb/validate",
-  "version": "1.0.1",
+  "version": "1.0.2-beta.0",
   "description": "Validation utilities for Power Platform ToolBox tool packages",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pptb/validate",
-  "version": "1.0.2-beta.0",
+  "version": "1.0.2",
   "description": "Validation utilities for Power Platform ToolBox tool packages",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/validation/src/validate.ts
+++ b/packages/validation/src/validate.ts
@@ -25,6 +25,7 @@ export interface Configurations {
 
 export interface Features {
     multiConnection?: "required" | "optional" | "none";
+    connectionRequirement?: "required" | "optional";
     minAPI?: string;
     enabledForPowerPlatformAPI?: boolean;
 }
@@ -92,6 +93,8 @@ export interface PPTBConfig {
 export const APPROVED_LICENSES = ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "GPL-2.0", "GPL-3.0", "LGPL-3.0", "ISC", "AGPL-3.0-only"];
 
 export const VALID_MULTI_CONNECTION_VALUES = ["required", "optional", "none"] as const;
+
+export const VALID_CONNECTION_REQUIREMENT_VALUES = ["required", "optional"] as const;
 
 /**
  * Keep in sync with BUILT_IN_CAPABILITY_TAGS in
@@ -329,9 +332,9 @@ export async function validatePackageJson(packageJson: ToolPackageJson, options:
     if (packageJson.features !== undefined) {
         const features = packageJson.features;
         if (features === null || typeof features !== "object" || Array.isArray(features)) {
-            errors.push("features must be a non-array object with optional 'multiConnection', 'minAPI', and 'enabledForPowerPlatformAPI' properties");
+            errors.push("features must be a non-array object with optional 'multiConnection', 'connectionRequirement', 'minAPI', and 'enabledForPowerPlatformAPI' properties");
         } else {
-            const VALID_FEATURE_KEYS = ["multiConnection", "minAPI", "enabledForPowerPlatformAPI"];
+            const VALID_FEATURE_KEYS = ["multiConnection", "connectionRequirement", "minAPI", "enabledForPowerPlatformAPI"];
             const invalidKeys = Object.keys(features).filter((k) => !VALID_FEATURE_KEYS.includes(k));
             if (invalidKeys.length > 0) {
                 errors.push(`features can only contain ${VALID_FEATURE_KEYS.map((k) => `'${k}'`).join(", ")} properties. Invalid properties: ${invalidKeys.join(", ")}`);
@@ -340,6 +343,9 @@ export async function validatePackageJson(packageJson: ToolPackageJson, options:
                 errors.push("features.multiConnection is required when features object is provided");
             } else if (!(VALID_MULTI_CONNECTION_VALUES as readonly string[]).includes(features.multiConnection)) {
                 errors.push(`features.multiConnection must be one of: ${VALID_MULTI_CONNECTION_VALUES.join(", ")}`);
+            }
+            if (features.connectionRequirement !== undefined && !(VALID_CONNECTION_REQUIREMENT_VALUES as readonly string[]).includes(features.connectionRequirement)) {
+                errors.push(`features.connectionRequirement must be one of: ${VALID_CONNECTION_REQUIREMENT_VALUES.join(", ")}`);
             }
             if (features.minAPI !== undefined) {
                 if (typeof features.minAPI !== "string" || !SEMVER_REGEX.test(features.minAPI)) {
@@ -467,7 +473,7 @@ export function validatePPTBConfig(config: PPTBConfig): ValidationResult {
                 } else {
                     agents.modes.forEach((mode, idx) => {
                         if (mode !== "one-way" && mode !== "two-way") {
-                            errors.push(`agents.modes[${idx}] must be either \"one-way\" or \"two-way\"`);
+                            errors.push(`agents.modes[${idx}] must be either "one-way" or "two-way"`);
                         }
                     });
                 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,8 +118,8 @@ importers:
   packages/types:
     dependencies:
       '@pptb/validate':
-        specifier: 1.0.2-beta.0
-        version: 1.0.2-beta.0
+        specifier: 1.0.2
+        version: 1.0.2
 
   packages/validation:
     dependencies:
@@ -830,8 +830,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@pptb/validate@1.0.2-beta.0':
-    resolution: {integrity: sha512-2fVvDgk4mizC8IJHrqyGRO3cSfe+NWfKHs0yQm7VpWf+tTXdqASliLhLKo1ZjnoDUFEdwMSQuFpMlQTl61hf8A==}
+  '@pptb/validate@1.0.2':
+    resolution: {integrity: sha512-D6bfEa1a7p9ju7BUY2l/jJ8tK7s5SEtpvNriBRfasazP91mJ6eL5mLqOGwwjQ9aPyRJoeFyVmdF4gRyFMCcG7Q==}
     hasBin: true
 
   '@rollup/rollup-android-arm-eabi@4.55.1':
@@ -4737,7 +4737,7 @@ snapshots:
     dependencies:
       playwright: 1.60.0
 
-  '@pptb/validate@1.0.2-beta.0':
+  '@pptb/validate@1.0.2':
     dependencies:
       tar: 7.5.16
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,8 +118,8 @@ importers:
   packages/types:
     dependencies:
       '@pptb/validate':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: 1.0.2-beta.0
+        version: 1.0.2-beta.0
 
   packages/validation:
     dependencies:
@@ -830,8 +830,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@pptb/validate@0.0.2':
-    resolution: {integrity: sha512-QsuimcuDgEbblqC4uAeXE+ONm5KJ5twKbGFh9d8e4leF2jsISgVpVzYPgivSLUA9iomDGmMnXcklHPgb4jEf1A==}
+  '@pptb/validate@1.0.2-beta.0':
+    resolution: {integrity: sha512-2fVvDgk4mizC8IJHrqyGRO3cSfe+NWfKHs0yQm7VpWf+tTXdqASliLhLKo1ZjnoDUFEdwMSQuFpMlQTl61hf8A==}
     hasBin: true
 
   '@rollup/rollup-android-arm-eabi@4.55.1':
@@ -4737,7 +4737,7 @@ snapshots:
     dependencies:
       playwright: 1.60.0
 
-  '@pptb/validate@0.0.2':
+  '@pptb/validate@1.0.2-beta.0':
     dependencies:
       tar: 7.5.16
 

--- a/src/common/types/tool.ts
+++ b/src/common/types/tool.ts
@@ -30,6 +30,12 @@ export interface ToolFeatures {
      */
     multiConnection?: "required" | "optional" | "none";
     /**
+     * Whether a connection is mandatory before the tool can be opened
+     * - "required": A connection (per `multiConnection`) must be selected before launch (default behavior)
+     * - "optional": The tool opens immediately with no connection; the user can attach one later via "Change Connection"
+     */
+    connectionRequirement?: "required" | "optional";
+    /**
      * Minimum ToolBox API version required by this tool
      * Tool developers should specify this in their package.json
      * @example "1.0.12"

--- a/src/main/managers/toolWindowManager.ts
+++ b/src/main/managers/toolWindowManager.ts
@@ -603,8 +603,11 @@ export class ToolWindowManager {
 
         // Multi-connection: if the callee requires a secondary connection but none was provided,
         // ask the main renderer to show the multi-connection selector before launching the tool.
+        // Tools declaring features.connectionRequirement === "optional" never block on connection
+        // selection, so they skip this prompt even if they support multi-connection.
+        const connectionRequirement = tool.features?.connectionRequirement ?? "required";
         const multiConnectionMode = tool.features?.multiConnection ?? "none";
-        const needsSecondary = multiConnectionMode === "required" || multiConnectionMode === "optional";
+        const needsSecondary = connectionRequirement === "required" && (multiConnectionMode === "required" || multiConnectionMode === "optional");
         let effectiveSecondaryConnectionId = secondaryConnectionId;
 
         if (needsSecondary && !effectiveSecondaryConnectionId) {

--- a/src/renderer/modules/toolManagement.ts
+++ b/src/renderer/modules/toolManagement.ts
@@ -377,6 +377,9 @@ export async function launchTool(toolId: string, options?: LaunchToolOptions): P
 
         // Determine multi-connection mode
         const multiConnectionMode = tool.features?.multiConnection || "none";
+        // Tools declaring "optional" never block launch on connection selection; the user can
+        // attach connection(s) later via "Change Connection" on the tab context menu.
+        const connectionRequirement = tool.features?.connectionRequirement || "required";
 
         const resolveConnectionId = async (connectionId: string | null): Promise<string | null> => {
             if (!connectionId) {
@@ -403,7 +406,11 @@ export async function launchTool(toolId: string, options?: LaunchToolOptions): P
             secondaryConnectionId = await resolveConnectionId(secondaryConnectionId);
         }
 
-        if (multiConnectionMode === "required" || multiConnectionMode === "optional") {
+        if (connectionRequirement === "optional") {
+            // Connectionless-capable tool: launch immediately with whatever connection(s) were
+            // already resolved (possibly none). No blocking modal is shown.
+            logInfo("Tool does not require a connection to launch; skipping connection selection.", { primaryConnectionId, secondaryConnectionId });
+        } else if (multiConnectionMode === "required" || multiConnectionMode === "optional") {
             // Tool supports multi-connection - show multi-connection modal
             const isSecondaryRequired = multiConnectionMode === "required";
             logInfo(


### PR DESCRIPTION
<!-- PR title format: [Type] Brief description — e.g. [Feature] Add connection export  -->
<!-- Types: [Feature] | [Fix] | [Docs] | [Refactor] | [Chore] | [Test] -->
<!-- Target branch: dev (not main) -->

## Summary

This pull request introduces support for a new `features.connectionRequirement` property in tool package definitions, allowing tools to specify whether a connection is required before launch or can be attached later. The changes update type definitions, validation logic, documentation, and tool launch behavior to accommodate this new property. Additionally, there are minor dependency and error message improvements.

Closes #649 

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Chore / maintenance (dependency update, build, config)
- [ ] Test addition / improvement

## Changes

<!-- List the key files/areas changed and what was done. Be specific enough for a reviewer to navigate the diff. -->

**Support for `features.connectionRequirement`:**

- Added the `connectionRequirement` property to the `Features`/`ToolFeatures` interfaces, allowing values `"required"` or `"optional"`, and updated documentation to describe its effect on tool launch behavior. (`packages/validation/src/validate.ts`, `src/common/types/tool.ts`, `packages/types/README.md`, [[1]](diffhunk://#diff-b8af4c52dcc1949ea476da8f12f41c0b3e355d9da7e11577cbe7d94e81294027R28) [[2]](diffhunk://#diff-0757c57c48b368a6097c97f0545578034acd6ff5198e7e1f5c6bde741c692cb2R32-R37) [[3]](diffhunk://#diff-338878d368fc59a12766753a76207a892f090da5fbb5b152707d8dad21003e9dR124)
- Updated tool launch logic in both the main and renderer processes to respect `connectionRequirement`, enabling tools to launch without a connection when set to `"optional"`. (`src/main/managers/toolWindowManager.ts`, `src/renderer/modules/toolManagement.ts`, [[1]](diffhunk://#diff-3192c3ef9f612393625ffc2e0bafa2589d667d6e5b63817302367272e22e4963R606-R610) [[2]](diffhunk://#diff-8f652c9ef8fae7cb4ed27d4a48137cc5938b4cef0a38d3d58b09907415bbf5e2R380-R382) [[3]](diffhunk://#diff-8f652c9ef8fae7cb4ed27d4a48137cc5938b4cef0a38d3d58b09907415bbf5e2L406-R413)

**Validation and error messaging:**

- Enhanced validation in both JavaScript and TypeScript to check for valid values of `connectionRequirement`, and updated error messages and allowed keys for the `features` object accordingly. (`packages/lib/validate.js`, `packages/validation/src/validate.ts`, [[1]](diffhunk://#diff-f61a15a3850e69fa7876767301a2621da54b0e57fc8db65eab81e2bc1846fb98L12-R12) [[2]](diffhunk://#diff-f61a15a3850e69fa7876767301a2621da54b0e57fc8db65eab81e2bc1846fb98L315-R320) [[3]](diffhunk://#diff-f61a15a3850e69fa7876767301a2621da54b0e57fc8db65eab81e2bc1846fb98R334-R337) [[4]](diffhunk://#diff-b8af4c52dcc1949ea476da8f12f41c0b3e355d9da7e11577cbe7d94e81294027L332-R337) [[5]](diffhunk://#diff-b8af4c52dcc1949ea476da8f12f41c0b3e355d9da7e11577cbe7d94e81294027R347-R349)

**Documentation and dependency updates:**

- Updated documentation to reflect the new property and its behavior, and incremented package versions and dependencies to beta releases for both `@pptb/types` and `@pptb/validate`. (`packages/types/README.md`, `packages/types/package.json`, `packages/validation/package.json`, `pnpm-lock.yaml`, [[1]](diffhunk://#diff-d20e06952213067104fa5b4a1976cbc97cd55806ac11d137d92c905d63c15054L3-R3) [[2]](diffhunk://#diff-d20e06952213067104fa5b4a1976cbc97cd55806ac11d137d92c905d63c15054L27-R27) [[3]](diffhunk://#diff-347daf1ac42a362936abe7a7dab5eac4fb6568f7a06f96e0c040cab7a5d262c1L3-R3) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL121-R122) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL833-R834) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4740-R4740)

**Minor fixes:**

- Corrected a string escape in error messages for agent mode validation. (`packages/lib/validate.js`, `packages/validation/src/validate.ts`, [[1]](diffhunk://#diff-f61a15a3850e69fa7876767301a2621da54b0e57fc8db65eab81e2bc1846fb98L470-R477) [[2]](diffhunk://#diff-b8af4c52dcc1949ea476da8f12f41c0b3e355d9da7e11577cbe7d94e81294027L470-R476)
- Fixed a table formatting issue in the documentation. (`packages/types/README.md`, [packages/types/README.mdL110-R110](diffhunk://#diff-338878d368fc59a12766753a76207a892f090da5fbb5b152707d8dad21003e9dL110-R110))

## Architecture checklist

### Packages (`types` & `validation`)

<!-- Only fill in this section if you touched files under packages/. Otherwise delete it. -->

- [ ] **Not applicable** — no changes to `packages/`

If you did change a package:

- [x] `@pptb/types` (`types`): type definitions updated and version bumped in `packages/types/package.json`
- [x] `@pptb/validate` (`validation`): validation rules updated and version bumped in `packages/validation/package.json`

### Code quality

- [x] `pnpm run typecheck` passes with **0 errors** (warnings are acceptable)
- [x] `pnpm run lint` passes with **0 errors** (warnings are acceptable)
- [x] `pnpm run build` completes successfully

## Testing

<!-- Describe how you verified this change works. -->

- [x] `pnpm run test:unit` passes (for changes to `src/main/`, `src/common/`, or `src/renderer/` utilities)
- [x] `pnpm run test:e2e` passes (for UI / navigation / end-to-end flows)
- [x] Manually tested in the running app (`pnpm run dev`)

**Scenario tested:**

<!-- e.g. "Opened the app, navigated to X, confirmed Y behaviour" -->

## Screenshots / recordings

<!-- Attach screenshots or a short screen recording for any UI change. Delete this section if not applicable. -->

## Breaking changes

<!-- Does this change affect the tool API (`toolboxAPI` / `dataverseAPI`), existing IPC channels, or `pptoolbox-types`? -->

- [x] No breaking changes
- [ ] Yes — describe impact and migration path below:

<!-- Breaking change details -->

## Reviewer notes

<!-- Anything specific you'd like reviewers to focus on, or context that helps them review faster. -->

- [x] I have added appropriate unit and/or e2e tests for this change
- [x] I have resolved all GitHub Copilot review comments
- [x] I have followed the guidelines in [CONTRIBUTING.md](https://github.com/PowerPlatformToolBox/desktop-app/blob/dev/CONTRIBUTING.md#pull-requests)
